### PR TITLE
Make minItemWidth optional by defaulting to 0

### DIFF
--- a/src/example-app/examples/GridMinimumSetup.js
+++ b/src/example-app/examples/GridMinimumSetup.js
@@ -14,12 +14,10 @@ import { itemStyle } from "../styles";
 import "react-listitem-grid/Grid/styles.css";
 
 const maxItemWidth = 350;
-const minItemWidth = 150;
 
 export default function GridMinimumSetup() {
   const { containerWidth, rowCount, containerRef } = useCalculateLayout({
     maxItemWidth,
-    minItemWidth,
   });
 
   const [cards, setCards] = React.useState([]);

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -12,7 +12,7 @@ export type Params = {|
   ...Options,
   columnGap?: number,
   maxItemWidth: number,
-  minItemWidth: number,
+  minItemWidth?: number,
   maxRows?: number,
 |};
 
@@ -20,7 +20,7 @@ export const calculateLayoutSpec = ({
   containerWidth: _containerWidth,
   columnGap = defaults.columnGap,
   maxItemWidth: _maxItemWidth,
-  minItemWidth,
+  minItemWidth = 0,
   maxRows,
   maximizeItemsPerRow = false,
   isFlex = false,
@@ -29,8 +29,7 @@ export const calculateLayoutSpec = ({
   containerWidth: number,
 |}) => {
   const containerWidth = isFlex ? _containerWidth - columnGap : _containerWidth;
-  const maxItemWidth =
-    _maxItemWidth < minItemWidth ? minItemWidth : _maxItemWidth;
+  const maxItemWidth = Math.max(_maxItemWidth, minItemWidth);
 
   const maxCount = Math.max(
     Math.floor(


### PR DESCRIPTION
When no `minItemWidth` is provided we can safely default to `0`. This allows us to still compute for `maxItemWidth` and have things work properly.

Note that since it's set to `0`, the math evaluates `maxCount` inside the `calculateLayoutSpec` hook to `Infinity` (which is technically true) and if you set `maximizeItemsPerRow` to `true` it will pile all of the children into one row.

We could set the default to `1` which would evaluate to the the width of the container and if you set `maximizeItemsPerRow` to `true` it will pile all of the children into one row up to that amount (e.g. 1024) which is still a lot, but has a limit.

I'm not sure if there's any possible compatibility difficulties with doing math with Infinity, but it seems to work fine (e.g. Infinity - 1 = Infinity, Infinity * 2 = Infinity) and so I've kept the default at 0, but would love some feedback there.

This use-case is obviously meant for when `maximizeItemsPerRow` is also not configured/false and is meant to simplify "out-of-the-box" configuration. But the calculations will technically still work when `maximizeItemsPerRow` is set to true, though the user experience will suffer.

I purposely did not make `maxItemWidth` optional because that would erase the purpose of using this library as per the readme:

> #### 🚫 Don't Use This Library
> * Your list item has a fixed width.
> * **Your list item only has minimum width, but can freely grow to any size.**